### PR TITLE
Make thunder less common in blizzards 

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,6 +8,7 @@
 - Change: [#25201] Ride List: put unknown popularity and satisfaction last when sorting.
 - Change: [#25228] [Plugin] The available staff costumes array is now ordered alphabetically by name.
 - Change: [#25248] Revert Crooked House & Circus default prices to vanilla values.
+- Change: [#25266] Lightning and thunder has less chance of occurring during blizzards.
 - Removed: [#25225] `sprite exportalldat`, replaced with `sprite exportobject`.
 - Fix: [#24513] Ride/track designs can now be shifted underground as well.
 - Fix: [#24682] The scenery window isn't high enough to accommodate all tool buttons when there are multiple rows of groups/tabs.

--- a/src/openrct2/world/Climate.cpp
+++ b/src/openrct2/world/Climate.cpp
@@ -205,13 +205,18 @@ void ClimateUpdate()
         ClimateUpdateLightning();
         ClimateUpdateThunder();
     }
-    else if (
-        gameState.weatherCurrent.weatherEffect == WeatherEffectType::Storm
-        || gameState.weatherCurrent.weatherEffect == WeatherEffectType::Blizzard)
+    else
     {
+        uint32_t thunderChance;
+        if (gameState.weatherCurrent.weatherEffect == WeatherEffectType::Storm)
+            thunderChance = 0x1B4;
+        else if (gameState.weatherCurrent.weatherEffect == WeatherEffectType::Blizzard)
+            thunderChance = 0x6D;
+        else
+            return;
         // Create new thunder and lightning. Their amount is scaled inversely proportional
         // to the game speed, otherwise they become annoying at very high speeds
-        if (uint32_t randomNumber = UtilRand(); (randomNumber & 0xFFFF) <= (0x1B4u >> (gGameSpeed - 1)))
+        if (uint32_t randomNumber = UtilRand(); (randomNumber & 0xFFFF) <= thunderChance >> (gGameSpeed - 1))
         {
             randomNumber >>= 16;
             _thunderTimer = 43 + (randomNumber % 64);

--- a/src/openrct2/world/Climate.cpp
+++ b/src/openrct2/world/Climate.cpp
@@ -216,7 +216,7 @@ void ClimateUpdate()
             return;
         // Create new thunder and lightning. Their amount is scaled inversely proportional
         // to the game speed, otherwise they become annoying at very high speeds
-        if (uint32_t randomNumber = UtilRand(); (randomNumber & 0xFFFF) <= thunderChance >> (gGameSpeed - 1))
+        if (uint32_t randomNumber = UtilRand(); (randomNumber & 0xFFFF) <= (thunderChance >> (gGameSpeed - 1)))
         {
             randomNumber >>= 16;
             _thunderTimer = 43 + (randomNumber % 64);


### PR DESCRIPTION
It was pointed out on Discord that thundersnow is a relatively rare occurrence in real life, so this PR makes it so thunder has a quarter of the chance it normally has to occur during blizzards. It's still common, but noticeably less so than during thunderstorms. This might seem like an unnecessary change, but do I think it would benefit the snow weathers a lot if sensible differences were introduced to further separate them from their rain counterparts and make them more fleshed out.